### PR TITLE
Don't enable `sensible-defaults/backup-to-temp-directory` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,18 @@ choices, but whatevs, it's easy:
 ```
 
 That's it!
+
+## Non-Default Settings
+
+The `sensible-defaults/backup-to-temp-directory` setting isn't enabled by
+default (i.e., it isn't included in `sensible-defaults/use-all-settings`), since
+it could lead to unexpected data loss in some cases.
+
+If you're the sort of person who doesn't rely much on backups and saves
+reflexively, though, this might be a perfectly fine choice for you.
+
+If you choose to enable it, just call it like any of the other functions:
+
+``` emacs
+(sensible-defaults/backup-to-temp-directory)
+```

--- a/sensible-defaults.el
+++ b/sensible-defaults.el
@@ -52,16 +52,6 @@ garbage collection. This means GC runs less often, which speeds
 up some operations."
   (setq gc-cons-threshold 20000000))
 
-(defun sensible-defaults/backup-to-temp-directory ()
-  "Store backups and auto-saved files in
-TEMPORARY-FILE-DIRECTORY (which defaults to /tmp on Unix),
-instead of in the same directory as the file. This means we're
-still making backups, but not where they'll get in the way."
-  (setq backup-directory-alist
-        `((".*" . ,temporary-file-directory)))
-  (setq auto-save-file-name-transforms
-        `((".*" ,temporary-file-directory t))))
-
 (defun sensible-defaults/delete-trailing-whitespace ()
   "Call DELETE-TRAILING-WHITESPACE every time a buffer is saved."
   (add-hook 'before-save-hook 'delete-trailing-whitespace))
@@ -167,7 +157,6 @@ insert the text where point is, not where the mouse cursor is."
   "Use all of the sensible-defaults settings."
   (sensible-defaults/open-files-from-home-directory)
   (sensible-defaults/increase-gc-threshold)
-  (sensible-defaults/backup-to-temp-directory)
   (sensible-defaults/delete-trailing-whitespace)
   (sensible-defaults/treat-camelcase-as-separate-words)
   (sensible-defaults/automatically-follow-symlinks)
@@ -216,5 +205,22 @@ respectively."
   (sensible-defaults/bind-commenting-and-uncommenting)
   (sensible-defaults/bind-home-and-end-keys)
   (sensible-defaults/bind-keys-to-change-text-size))
+
+;; Non-default settings:
+
+(defun sensible-defaults/backup-to-temp-directory ()
+  "Store backups and auto-saved files in
+TEMPORARY-FILE-DIRECTORY (which defaults to /tmp on Unix),
+instead of in the same directory as the file. This means we're
+still making backups, but not where they'll get in the way.
+
+WARNING: on most Unix-like systems /tmp is volatile, in-memory
+storage, so your backups won't survive if your computer crashes!
+If you're not willing to take this risk, you shouldn't enable
+this setting."
+  (setq backup-directory-alist
+        `((".*" . ,temporary-file-directory)))
+  (setq auto-save-file-name-transforms
+        `((".*" ,temporary-file-directory t))))
 
 ;;; sensible-defaults.el ends here


### PR DESCRIPTION
Since this setting stores backup files in the volatile `/tmp` directory, a user could lose data if their computer crashes. That's not a very sensible default!

However, some users might still find it useful. This commit removes it from the set of default settings, but leaves it as an optional, non-default setting.

Thanks to @michaelcadilhac for reporting this problem in https://github.com/hrs/sensible-defaults.el/issues/7!